### PR TITLE
Remove use of Object in ResponseTable

### DIFF
--- a/src/components/SummaryPanel/ResponseTable.tsx
+++ b/src/components/SummaryPanel/ResponseTable.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { Responses } from '../../types/Graph';
+import _ from 'lodash';
 
 type ResponseTableProps = {
   responses: Responses;
   title: string;
 };
 
+interface Row {
+  code: string;
+  flags: string;
+  key: string;
+  val: string;
+}
+
 // The Envoy flags can be found here:
 // https://github.com/envoyproxy/envoy/blob/master/source/common/stream_info/utility.cc
-const FLAGS = Object.freeze({
+const Flags: object = {
   DC: { code: '500', help: 'Downstream Connection Termination' },
   DI: { help: 'Delayed via fault injection' },
   FI: { help: 'Aborted via fault injection' },
@@ -26,7 +34,7 @@ const FLAGS = Object.freeze({
   UR: { code: '503', help: 'Upstream remote reset' },
   URX: { code: '503', help: 'Upstream retry limit exceeded' },
   UT: { code: '504', help: 'Upstream request timeout' }
-});
+};
 
 export class ResponseTable extends React.PureComponent<ResponseTableProps> {
   constructor(props: ResponseTableProps) {
@@ -59,10 +67,10 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
     );
   }
 
-  private getRows = (responses: Responses): Object[] => {
-    const rows: Object[] = [];
-    Object.keys(responses).map(code => {
-      Object.keys(responses[code]).map(f => {
+  private getRows = (responses: Responses): Row[] => {
+    const rows: Row[] = [];
+    _.keys(responses).map(code => {
+      _.keys(responses[code]).map(f => {
         rows.push({ key: `${code} ${f}`, code: code, flags: f, val: responses[code][f] });
       });
     });
@@ -74,7 +82,7 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
       .split(',')
       .map(flagToken => {
         flagToken = flagToken.trim();
-        const flag = FLAGS[flagToken];
+        const flag = Flags[flagToken];
         return flagToken === '-' ? '' : `[${flagToken}] ${flag ? flag.help : 'Unknown Flag'}`;
       })
       .join('\n');

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -84,7 +84,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     // Hack to force redisplay of annotations after update
     // See https://github.com/securingsincity/react-ace/issues/300
     if (this.aceEditorRef.current) {
-      this.aceEditorRef.current!.editor.onChangeAnnotation();
+      this.aceEditorRef.current!['editor'].onChangeAnnotation();
     }
 
     if (this.props.match.params !== prevProps.match.params) {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -112,7 +112,7 @@ export const getNamespaceTls = (namespace: string) => {
 export const getIstioConfig = (namespace: string, objects: string[], validate: boolean) => {
   const params = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
   if (validate) {
-    params.validate = validate;
+    params['validate'] = validate;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };
@@ -378,7 +378,7 @@ export const getServiceDetail = (
 ): Promise<ServiceDetailsInfo> => {
   const params = {};
   if (validate) {
-    params.validate = true;
+    params['validate'] = true;
   }
   return newRequest<ServiceDetailsInfo>(HTTP_VERBS.GET, urls.service(namespace, service), params, {}).then(r => {
     const info: ServiceDetailsInfo = r.data;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -93,7 +93,7 @@ export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 //     flags0: %traffic,
 //     flags1: %traffic
 //   }}
-export type Responses = Object;
+export type Responses = object;
 
 export type ProtocolTrafficNoData = {
   protocol: '';


### PR DESCRIPTION
@mtho11 Note that this re-introduces 3 instances of literal use because the type-support is not yet in your base PR.  I needed the code to run to test my changes.