### PR TITLE
Fix OverviewPage.test, mock API calls

### DIFF
--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -41,6 +41,11 @@ const mockNamespaceHealth = (obj: NamespaceAppHealth): Promise<void> => {
   return mockAPIToPromise('getNamespaceAppHealth', obj, false);
 };
 
+// Ignore other calls
+mockAPIToPromise('getNamespaceMetrics', null, false);
+mockAPIToPromise('getNamespaceTls', null, false);
+mockAPIToPromise('getNamespaceValidations', null, false);
+
 let mounted: ReactWrapper<any, any> | null;
 
 const mountPage = () => {
@@ -227,7 +232,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name no match', done => {
+  it('filters namespaces info name no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -242,7 +247,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name and health match', done => {
+  it('filters namespaces info name and health match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -268,7 +273,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name and health no match', done => {
+  it('filters namespaces info name and health no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',


### PR DESCRIPTION
@mtho11 this should make the tests pass.

Note that it's still worth investigating, because I wouldn't expect that these failing API calls here would impact the parts that are under test ... and I wonder if it's not again related to the other issue you looked at, https://github.com/kiali/kiali/issues/1935 . So I'll continue to investigate but in the meantime I think this patch it good to take.